### PR TITLE
fix rpc port and typo

### DIFF
--- a/lib/kaspa/client/kaspa_client.dart
+++ b/lib/kaspa/client/kaspa_client.dart
@@ -23,7 +23,7 @@ class VoidKaspaClient extends KaspaClient {
       : super(
           channel: ClientChannel(
             'localhost',
-            port: 16210,
+            port: 16110,
             options: ChannelOptions(
               credentials: ChannelCredentials.insecure(),
             ),

--- a/lib/kaspa/network.dart
+++ b/lib/kaspa/network.dart
@@ -12,7 +12,7 @@ const String kKaspaNetworkIdSimnet = '$kKaspaNetworkSimnet';
 const String kKaspaNetworkIdDevnet = '$kKaspaNetworkDevnet';
 
 const int kMainnetRpcPort = 16110;
-const int kTestnetPpcPort = 16210;
+const int kTestnetRpcPort = 16210;
 const int kSimnetRpcPort = 16510;
 const int kDevnetRpcPort = 16610;
 
@@ -41,7 +41,7 @@ enum KaspaNetwork {
 
   int get defaultRpcPort => switch (this) {
         KaspaNetwork.mainnet => kMainnetRpcPort,
-        KaspaNetwork.testnet => kTestnetPpcPort,
+        KaspaNetwork.testnet => kTestnetRpcPort,
         KaspaNetwork.simnet => kSimnetRpcPort,
         KaspaNetwork.devnet => kDevnetRpcPort
       };
@@ -51,7 +51,7 @@ KaspaNetwork networkForPort(int port) {
   switch (port) {
     case kMainnetRpcPort:
       return KaspaNetwork.mainnet;
-    case kTestnetPpcPort:
+    case kTestnetRpcPort:
       return KaspaNetwork.testnet;
     case kSimnetRpcPort:
       return KaspaNetwork.simnet;


### PR DESCRIPTION
`localhost` was set to use the testnet port, I wasn’t sure if that was intentional. In this PR, I’ve updated it to use the mainnet port `16110` instead. Additionally, I fixed a small typo in `lib/kaspa/network.dart` where `Ppc` was mistakenly used instead of `Rpc`.